### PR TITLE
Update NuGet source credentials and API key in publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,14 +18,14 @@ jobs:
         run: dotnet nuget add source --username devantler --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/devantler/index.json"
       - name: Push to GitHub Packages
         run: dotnet nuget push src/**/*.nupkg --source "github" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
-#   publish-nuget:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v4
-#       - name: Set up .NET SDK
-#         uses: actions/setup-dotnet@v4.0.0
-#       - name: Pack
-#         run: dotnet pack --configuration Release
-#       - name: Push to NuGet
-#         run: dotnet nuget push src/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+  publish-nuget:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4.0.0
+      - name: Pack
+        run: dotnet pack --configuration Release
+      - name: Push to NuGet
+        run: dotnet nuget push src/**/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate


### PR DESCRIPTION
This pull request updates the NuGet source credentials and API key in the `publish.yaml` file. The changes ensure that the correct credentials are used when pushing packages to GitHub Packages.