### PR TITLE
Enable TreatWarningsAsErrors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,9 @@ dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
 # Apply our rule to constants.
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
+# Disable CA1014
+dotnet_diagnostic.CA1014.severity = none
+
 [*.{received,verified}.*]
 generated_code = true
 

--- a/Devantler.TemplateEngine.Tests/Devantler.TemplateEngine.Tests.csproj
+++ b/Devantler.TemplateEngine.Tests/Devantler.TemplateEngine.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/Devantler.TemplateEngine/Devantler.TemplateEngine.csproj
+++ b/Devantler.TemplateEngine/Devantler.TemplateEngine.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
This pull request enables the TreatWarningsAsErrors flag in the project file, which treats warnings as errors during the build process. Additionally, it disables the CA1014 diagnostic rule.